### PR TITLE
Set ISO Country Code dynamically via Getter

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,56 @@ Another way would be to use the constraint as an annotation of a class property,
 ```bash
 <?php
 
+use ZipCodeValidator\Constraints\ZipCode;
+
 class Address
 {
     /**
-     * @ZipCodeValidator\Constraints\ZipCode(iso="DE")
+     * @ZipCode(iso="DE")
      */
     protected $zipCode;
 }
 ```
 
 >  Please consider to inject a valid ISO 3166 2-letter country code (e.g. DE, US, FR)!
+
+### Use a getter to inject the country code dynamically
+
+If you have a form, in which the user can select a country, you may want to validate the zip code dynamically.
+In this case you can use the `getter` option instead:
+
+```php
+<?php
+
+use ZipCodeValidator\Constraints\ZipCode;
+
+class Address
+{
+    /**
+     * @ZipCode(getter="getCountry")
+     */
+    protected $zipCode;
+
+    protected $country;
+
+    public function getCountry()
+    {
+        return $this->country;
+    }
+}
+```
+
+To disable that the validator throws an exception, when the zip code pattern is not available for a country,
+you can set the `strict` option to `FALSE`.
+
+```php
+    /**
+     * @ZipCode(getter="getCountry", strict=false)
+     */
+    protected $zipCode;
+}
+```
+
 
 ## Copying / License
 This repository is distributed under the MIT License (MIT). You can find the whole license text in the LICENSE file.

--- a/src/ZipCodeValidator/Constraints/ZipCode.php
+++ b/src/ZipCodeValidator/Constraints/ZipCode.php
@@ -19,15 +19,27 @@ class ZipCode extends Constraint
      */
     public $message = 'This value is not a valid ZIP code.';
 
+    /**
+     * @var string
+     */
     public $iso;
 
     /**
+     * @var string
+     */
+    public $getter;
+
+    /**
+     * @var bool
+     */
+    public $strict = true;
+
+    /**
      * ZipCode constructor.
-     * @param null $options
+     * @param mixed $options
      */
     public function __construct($options = null)
     {
-
         if (null !== $options && !is_array($options)) {
             $options = array(
                 'iso' => $options
@@ -36,8 +48,8 @@ class ZipCode extends Constraint
 
         parent::__construct($options);
 
-        if (null === $this->iso) {
-            throw new MissingOptionsException(sprintf('The option "iso" must be given for constraint %s', __CLASS__), array('iso'));
+        if (null === $this->iso && null === $this->getter) {
+            throw new MissingOptionsException(sprintf('Either the option "iso" or "getter" must be given for constraint %s', __CLASS__), array('iso', 'getter'));
         }
     }
 


### PR DESCRIPTION
- setting the ISO country code dynamically via user input
- throwing UnexpectedTypeException, when constraint is not a ZipCode class
- throwing ConstraintDefinitionException when getter is invalid or pattern for iso code is not available
- ignore missing iso code pattern via option `strict=false`
