### PR TITLE
Excess check

### DIFF
--- a/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
+++ b/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
@@ -223,10 +223,6 @@ class ZipCodeValidator extends ConstraintValidator
             return;
         }
 
-        if(empty($constraint->iso)){
-            return;
-        }
-
         if (!($iso = strtoupper($constraint->iso))) {
             // if iso code is not specified, try to fetch it via getter from the object, which is currently validated
             $object = $this->context->getObject();


### PR DESCRIPTION
Config example:

postalCode: 
            - ZipCodeValidator\Constraints\ZipCode:
                    getter: getCountry
                    message: 'Invalid zip code'

In case when we use the "getter" option for getting iso value "$constraint->iso" always will be empty, but will be getting from an object after this condition. So, this verification is redundant, because we check iso some lines below.
