### PR TITLE
Change to allow the second part of an Irish postcode to be optional

### DIFF
--- a/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
+++ b/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
@@ -101,7 +101,7 @@ class ZipCodeValidator extends ConstraintValidator
         'HT' => '\\d{4}',
         'HU' => '\\d{4}',
         'ID' => '\\d{5}',
-        'IE' => '[\\dA-Z]{3} ?[\\dA-Z]{4}',
+        'IE' => '[\\dA-Z]{3}( ?[\\dA-Z]{4})?',
         'IL' => '\\d{5}(?:\\d{2})?',
         'IM' => 'IM\\d[\\dA-Z]? ?\\d[ABD-HJLN-UW-Z]{2}',
         'IN' => '\\d{6}',


### PR DESCRIPTION
Since updating to the latest stable version of your package I've noticed an issue when trying to validate Irish postcodes. Ireland previously didn't feature in the list of patterns.

Many of the 50k + Irish addresses we have in our database contain just the routing key (first three chars) as outlined here https://worldpostalcode.com/ireland/

However the regex for matching Irish postcodes within ZipCodeValidator.php also requires the the last four characters. 

I've made a small change to the regex making just the first three chars required and the last 4 chars are now optional. This allows all of the following Irish postcodes to be validated.

A12
A12B3C4
A12 B3C4