### PR TITLE
Change to allow the first part of Latvian postcode to be optional

### DIFF
--- a/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
+++ b/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
@@ -128,7 +128,7 @@ class ZipCodeValidator extends ConstraintValidator
         'LS' => '\\d{3}',
         'LT' => '\\d{5}',
         'LU' => '\\d{4}',
-        'LV' => 'LV-\\d{4}',
+        'LV' => '(LV-)?\\d{4}',
         'MA' => '\\d{5}',
         'MC' => '980\\d{2}',
         'MD' => '\\d{4}',


### PR DESCRIPTION
Similar to my last PR, DHL don't like the first part of Latvian postcodes being mandatory. 

This PR makes the "LV-" optional allowing just 4 digits to make up a Latvian postcode.