### PR TITLE
Improve and fix GB validation

### DIFF
--- a/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
+++ b/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
@@ -81,7 +81,7 @@ class ZipCodeValidator extends ConstraintValidator
         'FM' => '(9694[1-4])(?:[ \\-](\\d{4}))?',
         'FO' => '\\d{3}',
         'FR' => '\\d{1}(?:A|B|\\d{1}) ?\\d{3}',
-        'GB' => 'GIR ?0AA|(?:(?:AB|AL|B|BA|BB|BD|BH|BL|BN|BR|BS|BT|BX|CA|CB|CF|CH|CM|CO|CR|CT|CV|CW|DA|DD|DE|DG|DH|DL|DN|DT|DY|E|EC|EH|EN|EX|FK|FY|G|GL|GY|GU|HA|HD|HG|HP|HR|HS|HU|HX|IG|IM|IP|IV|JE|KA|KT|KW|KY|L|LA|LD|LE|LL|LN|LS|LU|M|ME|MK|ML|N|NE|NG|NN|NP|NR|NW|OL|OX|PA|PE|PH|PL|PO|PR|RG|RH|RM|S|SA|SE|SG|SK|SL|SM|SN|SO|SP|SR|SS|ST|SW|SY|TA|TD|TF|TN|TQ|TR|TS|TW|UB|W|WA|WC|WD|WF|WN|WR|WS|WV|YO|ZE)(?:\\d[\\dA-Z]? ?\\d[ABD-HJLN-UW-Z]{2}))|BFPO ?\\d{1,4}',
+        'GB' => '^GIR ?0AA$|^(?:(?:AB|AL|B|BA|BB|BD|BH|BL|BN|BR|BS|BT|BX|CA|CB|CF|CH|CM|CO|CR|CT|CV|CW|DA|DD|DE|DG|DH|DL|DN|DT|DY|E|EC|EH|EN|EX|FK|FY|G|GL|GY|GU|HA|HD|HG|HP|HR|HS|HU|HX|IG|IM|IP|IV|JE|KA|KT|KW|KY|L|LA|LD|LE|LL|LN|LS|LU|M|ME|MK|ML|N|NE|NG|NN|NP|NR|NW|OL|OX|PA|PE|PH|PL|PO|PR|RG|RH|RM|S|SA|SE|SG|SK|SL|SM|SN|SO|SP|SR|SS|ST|SW|SY|TA|TD|TF|TN|TQ|TR|TS|TW|UB|W|WA|WC|WD|WF|WN|WR|WS|WV|YO|ZE)(?:\\d[\\dA-Z]? ?\\d[ABD-HJLN-UW-Z]{2}))$|^BFPO ?\\d{1,4}$',
         'GE' => '\\d{4}',
         'GF' => '9[78]3\\d{2}',
         'GG' => 'GY\\d[\\dA-Z]? ?\\d[ABD-HJLN-UW-Z]{2}',

--- a/tests/GbZipCodeValidatorTest.php
+++ b/tests/GbZipCodeValidatorTest.php
@@ -1,0 +1,164 @@
+<?php
+
+use Mockery as m;
+use ZipCodeValidator\Constraints\ZipCode;
+use ZipCodeValidator\Constraints\ZipCodeValidator;
+
+class GbZipCodeValidatorTest extends PHPUnit_Framework_TestCase
+{
+    /** @var ZipCodeValidator */
+    protected $validator;
+
+    /** @var \Symfony\Component\Validator\Context\ExecutionContextInterface|\Mockery\Mock */
+    protected $context;
+
+    public function setUp()
+    {
+        $this->validator = new ZipCodeValidator;
+
+        $this->context = m::mock('\Symfony\Component\Validator\Context\ExecutionContext');
+
+        $this->validator->initialize($this->context);
+    }
+
+    protected function tearDown()
+    {
+        m::close();
+    }
+
+    /** @test */
+    public function it_validates_a_gb_zip_code_with_iso()
+    {
+        $constraint = new ZipCode('GB');
+
+        // Test some variations
+        $this->validator->validate('EC1A 1BB', $constraint);
+        $this->validator->validate('W1A 0AX', $constraint);
+        $this->validator->validate('M1 1AE', $constraint);
+        $this->validator->validate('B33 8TH', $constraint);
+        $this->validator->validate('CR2 6XH', $constraint);
+        $this->validator->validate('DN55 1PT', $constraint);
+        $this->validator->validate('BFPO 801', $constraint);
+        $this->validator->validate('GIR 0AA', $constraint);
+        $this->validator->validate('PH1 5RB', $constraint);
+        $this->validator->validate('CO4 3SQ', $constraint);
+        $this->validator->validate('CO4 3SQ', $constraint);
+    }
+
+    /** @test */
+    public function it_wont_validate_an_invalid_gb_zip_code()
+    {
+        $value = 'invalid';
+        $constraint = new ZipCode('GB');
+
+        // Non-mocked context object due to sheer complexity. Might need a refactor
+        $translator = new \Symfony\Component\Translation\Translator('en-US');
+        $context = new \Symfony\Component\Validator\Context\ExecutionContext(
+            new \Symfony\Component\Validator\Validator\RecursiveValidator(
+                new \Symfony\Component\Validator\Context\ExecutionContextFactory($translator),
+                new \Symfony\Component\Validator\Tests\Fixtures\FakeMetadataFactory(),
+                new \Symfony\Component\Validator\ConstraintValidatorFactory()
+            ),
+            null,
+            $translator
+        );
+
+        $context->setConstraint($constraint);
+        $this->validator->initialize($context);
+
+        $this->validator->validate($value, $constraint);
+
+        $this->assertEquals(
+            $constraint->message,
+            $context->getViolations()->get(0)->getMessage()
+        );
+    }
+
+    /** @test */
+    public function it_wont_validate_an_valid_gb_zip_code_with_extra_leading_chars()
+    {
+        $value = 'XEC1A 1BB';
+        $constraint = new ZipCode('GB');
+
+        // Non-mocked context object due to sheer complexity. Might need a refactor
+        $translator = new \Symfony\Component\Translation\Translator('en-US');
+        $context = new \Symfony\Component\Validator\Context\ExecutionContext(
+            new \Symfony\Component\Validator\Validator\RecursiveValidator(
+                new \Symfony\Component\Validator\Context\ExecutionContextFactory($translator),
+                new \Symfony\Component\Validator\Tests\Fixtures\FakeMetadataFactory(),
+                new \Symfony\Component\Validator\ConstraintValidatorFactory()
+            ),
+            null,
+            $translator
+        );
+
+        $context->setConstraint($constraint);
+        $this->validator->initialize($context);
+
+        $this->validator->validate($value, $constraint);
+
+        $this->assertEquals(
+            $constraint->message,
+            $context->getViolations()->get(0)->getMessage()
+        );
+    }
+
+    /** @test */
+    public function it_wont_validate_an_valid_gb_zip_code_with_extra_trainling_chars()
+    {
+        $value = 'EC1A 1BBX';
+        $constraint = new ZipCode('GB');
+
+        // Non-mocked context object due to sheer complexity. Might need a refactor
+        $translator = new \Symfony\Component\Translation\Translator('en-US');
+        $context = new \Symfony\Component\Validator\Context\ExecutionContext(
+            new \Symfony\Component\Validator\Validator\RecursiveValidator(
+                new \Symfony\Component\Validator\Context\ExecutionContextFactory($translator),
+                new \Symfony\Component\Validator\Tests\Fixtures\FakeMetadataFactory(),
+                new \Symfony\Component\Validator\ConstraintValidatorFactory()
+            ),
+            null,
+            $translator
+        );
+
+        $context->setConstraint($constraint);
+        $this->validator->initialize($context);
+
+        $this->validator->validate($value, $constraint);
+
+        $this->assertEquals(
+            $constraint->message,
+            $context->getViolations()->get(0)->getMessage()
+        );
+    }
+}
+
+class TestGbZipCodeConstraint extends ZipCode
+{
+    /** @var string */
+    public $getter = 'myValidationMethod';
+}
+
+class TestGbObject
+{
+    /** @var string */
+    protected $iso;
+
+    /**
+     * TestObject constructor.
+     *
+     * @param string $iso
+     */
+    public function __construct($iso)
+    {
+        $this->iso = $iso;
+    }
+
+    /**
+     * @return string
+     */
+    public function myValidationMethod()
+    {
+        return $this->iso;
+    }
+}


### PR DESCRIPTION
Currently any string that includes a valid zipcode is accepted eg:
`THISISNOTAPOSTCODEW1W8AJNEITHERISTHIS` contains `W1W8AJ` and therefore it will be accepted.
This PR fixes the issue forcing a start and end string match.

I've also added GB specific postcode validation tests with a few different patterns taken out of wikipedia. This will prevent any future PR's from breaking it.

I'm not too familiar with PhpUnit (we use PhpSpec) so feel free to suggest any improvements in the test class/names.