### PR TITLE
Added constraint option to specify property path for ISO code from data (array or object)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,24 @@ you can set the `ignoreEmpty` option to `TRUE`.
 }
 ```
 
+### Use a property path to inject the country code dynamically
+
+When working with form data as array or you have more complex objects in your form data the `getter` option does not work. You can instead use the `isoPropertyPath` option. If you're not inside the Symfony fullstack framework, you need to install the [Symfony PropertyAccess component](https://symfony.com/doc/current/components/property_access.html) first.
+
+```php
+$address = [
+    'country' => 'DE',
+];
+
+$builder = $this->createFormBuilder($address);
+$builder->add('country', TextType::class);
+$builder->add('zipcode', TextType::class, [
+    'constraints' => [
+         new ZipCode(['isoPropertyPath' => '[country]'])
+    ]
+]);
+```
+
 ### Case insensitive zip code matching
 In case you want to match the zip code in a case insensitive way you have to pass a `caseSensitiveCheck` parameter with `false` value via the constructor:
 ```php

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "5.7.*",
-        "mockery/mockery": "^0.9"
+        "mockery/mockery": "^0.9",
+        "symfony/property-access": ">=2.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/ZipCodeValidator/Constraints/ZipCode.php
+++ b/src/ZipCodeValidator/Constraints/ZipCode.php
@@ -32,7 +32,7 @@ class ZipCode extends Constraint
     /**
      * @var string
      */
-    public $propertyPath;
+    public $isoPropertyPath;
 
     /**
      * @var bool
@@ -63,8 +63,8 @@ class ZipCode extends Constraint
 
         parent::__construct($options);
 
-        if (null === $this->iso && null === $this->getter && null === $this->propertyPath) {
-            throw new MissingOptionsException(sprintf('Either the option "iso", "getter" or "propertyPath" must be given for constraint %s', __CLASS__), array('iso', 'getter', 'propertyPath'));
+        if (null === $this->iso && null === $this->getter && null === $this->isoPropertyPath) {
+            throw new MissingOptionsException(sprintf('Either the option "iso", "getter" or "isoPropertyPath" must be given for constraint %s', __CLASS__), array('iso', 'getter', 'isoPropertyPath'));
         }
     }
 

--- a/src/ZipCodeValidator/Constraints/ZipCode.php
+++ b/src/ZipCodeValidator/Constraints/ZipCode.php
@@ -30,6 +30,11 @@ class ZipCode extends Constraint
     public $getter;
 
     /**
+     * @var string
+     */
+    public $propertyPath;
+
+    /**
      * @var bool
      */
     public $strict = true;
@@ -58,8 +63,8 @@ class ZipCode extends Constraint
 
         parent::__construct($options);
 
-        if (null === $this->iso && null === $this->getter) {
-            throw new MissingOptionsException(sprintf('Either the option "iso" or "getter" must be given for constraint %s', __CLASS__), array('iso', 'getter'));
+        if (null === $this->iso && null === $this->getter && null === $this->propertyPath) {
+            throw new MissingOptionsException(sprintf('Either the option "iso", "getter" or "propertyPath" must be given for constraint %s', __CLASS__), array('iso', 'getter', 'propertyPath'));
         }
     }
 

--- a/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
+++ b/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
@@ -235,7 +235,7 @@ class ZipCodeValidator extends ConstraintValidator
                 $object = $this->context->getObject();
 
                 // try to get object from form data
-                if ($object === null && $this->context->getRoot() instanceof FormInterface) {
+                if ($object === null || $this->context->getRoot() instanceof FormInterface) {
                     $form = $this->context->getRoot();
                     $object = $form->getData();
                 }

--- a/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
+++ b/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
@@ -235,7 +235,7 @@ class ZipCodeValidator extends ConstraintValidator
                 $object = $this->context->getObject();
 
                 // try to get object from form data
-                if ($object === null || $this->context->getRoot() instanceof FormInterface) {
+                if ($this->context->getRoot() instanceof FormInterface) {
                     $form = $this->context->getRoot();
                     $object = $form->getData();
                 }

--- a/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
+++ b/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
@@ -232,11 +232,14 @@ class ZipCodeValidator extends ConstraintValidator
             // if iso code is not specified, try to fetch it via getter from the object, which is currently validated
 
             if ($constraint->getter || $constraint->isoPropertyPath) {
-                $object = $this->context->getRoot();
+                $object = $this->context->getObject();
 
-                if ($object instanceof FormInterface) {
-                    $object = $object->getData();
+                // try to get object from form data
+                if ($object === null && $this->context->getRoot() instanceof FormInterface) {
+                    $form = $this->context->getRoot();
+                    $object = $form->getData();
                 }
+
                 if ($constraint->getter) {
                     $getter = $constraint->getter;
                     if (!is_callable(array($object, $getter))) {

--- a/tests/ZipCodeValidatorTestConstraint.php
+++ b/tests/ZipCodeValidatorTestConstraint.php
@@ -53,8 +53,24 @@ class ZipCodeValidatorTest extends PHPUnit_Framework_TestCase
     /** @test */
     public function it_validates_a_zip_code_with_getter()
     {
-        $this->context->shouldReceive('getRoot')->once()
+        $this->context->shouldReceive('getObject')->once()
             ->andReturn(new TestObject('VN'));
+
+        $this->validator->validate(123456, new TestZipCodeGetterConstraint);
+    }
+
+    /** @test */
+    public function it_validates_a_zip_code_with_getter_from_form_data()
+    {
+        $this->context->shouldReceive('getObject')->once()
+            ->andReturn(null);
+
+        $form = m::mock('\Symfony\Component\Form\Form');
+        $form->shouldReceive('getData')->once()
+            ->andReturn(new TestObject('VN'));
+
+        $this->context->shouldReceive('getRoot')
+            ->andReturn($form);
 
         $this->validator->validate(123456, new TestZipCodeGetterConstraint);
     }
@@ -62,7 +78,7 @@ class ZipCodeValidatorTest extends PHPUnit_Framework_TestCase
     /** @test */
     public function it_validates_a_zip_code_with_property_path()
     {
-        $this->context->shouldReceive('getRoot')->once()
+        $this->context->shouldReceive('getObject')->once()
             ->andReturn(new TestObject('VN'));
 
         $this->validator->validate(123456, new ZipCode(['isoPropertyPath' => 'iso']));
@@ -71,10 +87,26 @@ class ZipCodeValidatorTest extends PHPUnit_Framework_TestCase
     /** @test */
     public function it_validates_a_zip_code_with_array_property_path()
     {
-        $this->context->shouldReceive('getRoot')->once()
+        $this->context->shouldReceive('getObject')->once()
             ->andReturn(['iso' => 'VN']);
 
         $this->validator->validate(123456, new ZipCode(['isoPropertyPath' => '[iso]']));
+    }
+
+    /** @test */
+    public function it_validates_a_zip_code_with_property_path_from_form_data()
+    {
+        $this->context->shouldReceive('getObject')->once()
+            ->andReturn(null);
+
+        $form = m::mock('\Symfony\Component\Form\Form');
+        $form->shouldReceive('getData')->once()
+            ->andReturn(new TestObject('VN'));
+
+        $this->context->shouldReceive('getRoot')
+            ->andReturn($form);
+
+        $this->validator->validate(123456, new ZipCode(['isoPropertyPath' => 'iso']));
     }
 
     /** @test */
@@ -147,7 +179,7 @@ class ZipCodeValidatorTest extends PHPUnit_Framework_TestCase
     /** @test */
     public function it_returns_blank_on_empty_iso()
     {
-        $this->context->shouldReceive('getRoot')->once()
+        $this->context->shouldReceive('getObject')->once()
             ->andReturn(new TestObject(null));
 
         $this->validator->validate('dummy', new TestZipCodeGetterConstraint);
@@ -159,7 +191,7 @@ class ZipCodeValidatorTest extends PHPUnit_Framework_TestCase
      */
     public function it_throws_an_exception_on_invalid_iso_if_strict_mode_is_true()
     {
-        $this->context->shouldReceive('getRoot')->once()
+        $this->context->shouldReceive('getObject')->once()
             ->andReturn(new TestObject('non-existing iso'));
 
         $this->validator->validate('dummy', new TestZipCodeGetterConstraint);

--- a/tests/ZipCodeValidatorTestConstraint.php
+++ b/tests/ZipCodeValidatorTestConstraint.php
@@ -53,10 +53,28 @@ class ZipCodeValidatorTest extends PHPUnit_Framework_TestCase
     /** @test */
     public function it_validates_a_zip_code_with_getter()
     {
-        $this->context->shouldReceive('getObject')->once()
+        $this->context->shouldReceive('getRoot')->once()
             ->andReturn(new TestObject('VN'));
 
-        $this->validator->validate(123456, new TestZipCodeConstraint);
+        $this->validator->validate(123456, new TestZipCodeGetterConstraint);
+    }
+
+    /** @test */
+    public function it_validates_a_zip_code_with_property_path()
+    {
+        $this->context->shouldReceive('getRoot')->once()
+            ->andReturn(new TestObject('VN'));
+
+        $this->validator->validate(123456, new ZipCode(['isoPropertyPath' => 'iso']));
+    }
+
+    /** @test */
+    public function it_validates_a_zip_code_with_array_property_path()
+    {
+        $this->context->shouldReceive('getRoot')->once()
+            ->andReturn(['iso' => 'VN']);
+
+        $this->validator->validate(123456, new ZipCode(['isoPropertyPath' => '[iso]']));
     }
 
     /** @test */
@@ -129,10 +147,10 @@ class ZipCodeValidatorTest extends PHPUnit_Framework_TestCase
     /** @test */
     public function it_returns_blank_on_empty_iso()
     {
-        $this->context->shouldReceive('getObject')->once()
+        $this->context->shouldReceive('getRoot')->once()
             ->andReturn(new TestObject(null));
 
-        $this->validator->validate('dummy', new TestZipCodeConstraint);
+        $this->validator->validate('dummy', new TestZipCodeGetterConstraint);
     }
 
     /**
@@ -141,17 +159,17 @@ class ZipCodeValidatorTest extends PHPUnit_Framework_TestCase
      */
     public function it_throws_an_exception_on_invalid_iso_if_strict_mode_is_true()
     {
-        $this->context->shouldReceive('getObject')->once()
+        $this->context->shouldReceive('getRoot')->once()
             ->andReturn(new TestObject('non-existing iso'));
 
-        $this->validator->validate('dummy', new TestZipCodeConstraint);
+        $this->validator->validate('dummy', new TestZipCodeGetterConstraint);
     }
 }
 
-class TestZipCodeConstraint extends ZipCode
+class TestZipCodeGetterConstraint extends ZipCode
 {
     /** @var string */
-    public $getter = 'myValidationMethod';
+    public $getter = 'getIso';
 }
 
 class TestObject
@@ -172,7 +190,7 @@ class TestObject
     /**
      * @return string
      */
-    public function myValidationMethod()
+    public function getIso()
     {
         return $this->iso;
     }

--- a/tests/ZipCodeValidatorTestConstraint.php
+++ b/tests/ZipCodeValidatorTestConstraint.php
@@ -56,6 +56,9 @@ class ZipCodeValidatorTest extends PHPUnit_Framework_TestCase
         $this->context->shouldReceive('getObject')->once()
             ->andReturn(new TestObject('VN'));
 
+        $this->context->shouldReceive('getRoot')
+            ->andReturnNull();
+
         $this->validator->validate(123456, new TestZipCodeGetterConstraint);
     }
 
@@ -63,7 +66,7 @@ class ZipCodeValidatorTest extends PHPUnit_Framework_TestCase
     public function it_validates_a_zip_code_with_getter_from_form_data()
     {
         $this->context->shouldReceive('getObject')->once()
-            ->andReturn(null);
+            ->andReturnNull();
 
         $form = m::mock('\Symfony\Component\Form\Form');
         $form->shouldReceive('getData')->once()
@@ -81,6 +84,9 @@ class ZipCodeValidatorTest extends PHPUnit_Framework_TestCase
         $this->context->shouldReceive('getObject')->once()
             ->andReturn(new TestObject('VN'));
 
+        $this->context->shouldReceive('getRoot')
+            ->andReturnNull();
+
         $this->validator->validate(123456, new ZipCode(['isoPropertyPath' => 'iso']));
     }
 
@@ -90,6 +96,9 @@ class ZipCodeValidatorTest extends PHPUnit_Framework_TestCase
         $this->context->shouldReceive('getObject')->once()
             ->andReturn(['iso' => 'VN']);
 
+        $this->context->shouldReceive('getRoot')
+            ->andReturnNull();
+
         $this->validator->validate(123456, new ZipCode(['isoPropertyPath' => '[iso]']));
     }
 
@@ -97,7 +106,7 @@ class ZipCodeValidatorTest extends PHPUnit_Framework_TestCase
     public function it_validates_a_zip_code_with_property_path_from_form_data()
     {
         $this->context->shouldReceive('getObject')->once()
-            ->andReturn(null);
+            ->andReturnNull();
 
         $form = m::mock('\Symfony\Component\Form\Form');
         $form->shouldReceive('getData')->once()
@@ -182,6 +191,9 @@ class ZipCodeValidatorTest extends PHPUnit_Framework_TestCase
         $this->context->shouldReceive('getObject')->once()
             ->andReturn(new TestObject(null));
 
+        $this->context->shouldReceive('getRoot')
+            ->andReturnNull();
+
         $this->validator->validate('dummy', new TestZipCodeGetterConstraint);
     }
 
@@ -193,6 +205,9 @@ class ZipCodeValidatorTest extends PHPUnit_Framework_TestCase
     {
         $this->context->shouldReceive('getObject')->once()
             ->andReturn(new TestObject('non-existing iso'));
+
+        $this->context->shouldReceive('getRoot')
+            ->andReturnNull();
 
         $this->validator->validate('dummy', new TestZipCodeGetterConstraint);
     }


### PR DESCRIPTION
This adds a new contraint option `isoPropertyPath` allowing to use validation of form data as array instead of objects:

```php
$address = [
    'country' => 'DE',
];

$builder = $this->createFormBuilder($address);
$builder->add('country', TextType::class);
$builder->add('zipcode', TextType::class, [
    'constraints' => [
         new ZipCode(['isoPropertyPath' => '[country]'])
    ]
]);
```
The existing `getter` option does not work in this case.
The new option `isoPropertyPath` uses the [Symfony Property Access component](https://symfony.com/components/PropertyAccess) for flexible definition on how to get the ISO country code from the data (can either be a get method name, array key or nested data structure). Theoretically this makes the `getter` option obsolete, but we should keep it for backwards compatibility.

This also fixes #23, which came up, when using the constraint inside the form building (like in example above) instead of using annotation.