### PR TITLE
Improve Spain validation

### DIFF
--- a/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
+++ b/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
@@ -74,7 +74,7 @@ class ZipCodeValidator extends ConstraintValidator
         'EE' => '\\d{5}',
         'EG' => '\\d{5}',
         'EH' => '\\d{5}',
-        'ES' => '[0-4][0-9]{4}|5[0-2][0-9]{3}',
+        'ES' => '^([0-4]\\d{4}|5[0-2]\\d{3})$',
         'ET' => '\\d{4}',
         'FI' => '\\d{5}',
         'FK' => 'FIQQ 1ZZ',

--- a/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
+++ b/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
@@ -74,7 +74,7 @@ class ZipCodeValidator extends ConstraintValidator
         'EE' => '\\d{5}',
         'EG' => '\\d{5}',
         'EH' => '\\d{5}',
-        'ES' => '\\d{5}',
+        'ES' => '[0-4][0-9]{4}|5[0-2][0-9]{3}',
         'ET' => '\\d{4}',
         'FI' => '\\d{5}',
         'FK' => 'FIQQ 1ZZ',

--- a/tests/Constraints/EsZipCodeValidatorTest.php
+++ b/tests/Constraints/EsZipCodeValidatorTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use Symfony\Component\Validator\Context\ExecutionContext;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+use ZipCodeValidator\Constraints\ZipCode;
+use ZipCodeValidator\Constraints\ZipCodeValidator;
+
+class EsZipCodeValidatorTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var ZipCodeValidator */
+    protected $validator;
+
+    public function setUp()
+    {
+        $this->validator = new ZipCodeValidator;
+    }
+
+    /**
+     * @dataProvider esValidZipCodes
+     * @param string $zipCode
+     */
+    public function testValidationOfEsZipCode($zipCode)
+    {
+        $constraint = new ZipCode('ES');
+
+        /** @var ExecutionContext|PHPUnit_Framework_MockObject_MockObject $contextMock */
+        $contextMock = $this->getMockBuilder(ExecutionContext::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        //be sure that buildViolation never gets called
+        $contextMock->expects($this->never())->method('buildViolation');
+
+        $contextMock->setConstraint($constraint);
+        $this->validator->initialize($contextMock);
+
+        // Test some variations
+        $this->validator->validate($zipCode, $constraint);
+    }
+
+    /**
+     * @return array
+     */
+    public function esValidZipCodes()
+    {
+        return [
+            ['08020'],
+            ['11231'],
+            ['52006'],
+            ['49739'],
+        ];
+    }
+
+    /**
+     * @dataProvider esInvalidZipCodes
+     * @param string $zipcode
+     */
+    public function testValidationErrorWithInvalidEsZipCode($zipcode)
+    {
+        $constraint = new ZipCode('ES');
+
+        $violationBuilderMock = $this->getMockBuilder(ConstraintViolationBuilderInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $violationBuilderMock->expects($this->once())->method('setParameter')->willReturnSelf();
+
+        /** @var ExecutionContext|PHPUnit_Framework_MockObject_MockObject $contextMock */
+        $contextMock = $this->getMockBuilder(ExecutionContext::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $contextMock->expects($this->exactly(1))
+            ->method('buildViolation')
+            ->with($constraint->message)
+            ->willReturn($violationBuilderMock);
+
+        $contextMock->setConstraint($constraint);
+        $this->validator->initialize($contextMock);
+        $this->validator->validate($zipcode, $constraint);
+    }
+
+    /**
+     * @return array
+     */
+    public function esInvalidZipCodes()
+    {
+        return [
+            ['53456'],
+            ['0413A'],
+            ['024567'],
+            ['es123'],
+            ['2341'],
+        ];
+    }
+
+
+}


### PR DESCRIPTION
Hi, 
Thanks for you library. 
I've noticed that the zip code validation for Spain is a bit too generous, it would pass for all the valid zip codes, but aswell for some invalid ones as 53123.

I propose to change the regexp to make it a bit more strict.

Theorically the spanish zip codes go from 01XXX to 52XXX, I propose this regexp but maybe we can find one more efficent or more strict.

I let here a bit of [documentation](https://es.wikipedia.org/wiki/C%C3%B3digo_postal_espa%C3%B1ol) (in spanish)

Thanks, Have a good day.