### PR TITLE
Added correct validation for Jamaica

### DIFF
--- a/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
+++ b/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
@@ -111,7 +111,7 @@ class ZipCodeValidator extends ConstraintValidator
         'IS' => '\\d{3}',
         'IT' => '\\d{5}',
         'JE' => 'JE\\d[\\dA-Z]? ?\\d[ABD-HJLN-UW-Z]{2}',
-        'JM' => '[\\a-zA-Z]{2}',
+        'JM' => '[a-zA-Z]{2}',
         'JO' => '\\d{5}',
         'JP' => '\\d{3}-?\\d{4}',
         'KE' => '\\d{5}',

--- a/tests/Constraints/JmZipCodeValidatorTest.php
+++ b/tests/Constraints/JmZipCodeValidatorTest.php
@@ -28,11 +28,11 @@ class JmZipCodeValidatorTest extends \PHPUnit\Framework\TestCase
     /**
      * This test verifies that all known Jamaica codes are valid.
      *
-     * @dataProvider getJamaicaZipCodes
+     * @dataProvider getValidJamaicaZipCodes
      * @test
      * @param string $zipCode
      */
-    public function testZipcodes($zipCode)
+    public function testValidZipcodes($zipCode)
     {
         $constraint = new ZipCode('JM');
 
@@ -55,7 +55,7 @@ class JmZipCodeValidatorTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function getJamaicaZipCodes()
+    public function getValidJamaicaZipCodes()
     {
         return [
             ['KN'],
@@ -67,4 +67,46 @@ class JmZipCodeValidatorTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
+    /**
+     * This test verifies that all known Jamaica codes are valid.
+     *
+     * @dataProvider getInvalidJamaicaZipCodes
+     * @test
+     * @param string $zipCode
+     */
+    public function testInvalidZipcodes($zipCode)
+    {
+        $constraint = new ZipCode('JM');
+
+        $violation = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $violation->expects($this->once())->method('setParameter')->willReturnSelf();
+
+        /** @var ExecutionContext|PHPUnit_Framework_MockObject_MockObject $contextMock */
+        $contextMock = $this->getMockBuilder(ExecutionContext::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        # be sure that buildViolation never gets called
+        $contextMock->expects($this->once())->method('buildViolation')->willReturn($violation);
+        $contextMock->setConstraint($constraint);
+
+        $this->validator->initialize($contextMock);
+        $this->validator->validate($zipCode, $constraint);
+    }
+
+    /**
+     * used postal codes
+     * from https://en.wikipedia.org/wiki/Postal_codes_in_Jamaica
+     *
+     * @return array
+     */
+    public function getInvalidJamaicaZipCodes()
+    {
+        return [
+            ['12'],
+            ['\W'],
+            ['A1'],
+            ['0z'],
+        ];
+    }
 }


### PR DESCRIPTION
see https://github.com/barbieswimcrew/zip-code-validator/issues/34

I actually noticed that the regex allowed for any two characters, the unit tests did not check for "invalid".