### PR TITLE
Ignore empty values. Fixes #39

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,18 +87,18 @@ you can set the `strict` option to `FALSE`.
 
 ```php
 /**
-* @ZipCode(getter="getCountry", strict=false)
-*/
+ * @ZipCode(getter="getCountry", strict=false)
+ */
 protected $zipCode;
 ```
 
-To avoid that the validation fails in case that there's an empty value in the zip code field
-you can set the `ignoreEmpty` option to `TRUE`.
+The validator will not validate empty strings and null values. To disallow them use the Symfony stock `NotNull` or `NotBlank` constraint in addition to `ZipCode`.
 
 ```php
 /**
-* @ZipCode(getter="getCountry", ignoreEmpty=true)
-*/
+ * @ZipCode(getter="getCountry")
+ * @NotBlank 
+ */
 protected $zipCode;
 ```
 

--- a/src/ZipCodeValidator/Constraints/ZipCode.php
+++ b/src/ZipCodeValidator/Constraints/ZipCode.php
@@ -37,11 +37,6 @@ class ZipCode extends Constraint
     /**
      * @var bool
      */
-    public $ignoreEmpty = false;
-
-    /**
-     * @var bool
-     */
     public $caseSensitiveCheck = true;
 
     /**

--- a/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
+++ b/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
@@ -224,7 +224,7 @@ class ZipCodeValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\ZipCode');
         }
 
-        if ($constraint->ignoreEmpty and empty($value)) {
+        if (null === $value || '' === $value) {
             return;
         }
 

--- a/tests/Constraints/ZipCodeValidatorTest.php
+++ b/tests/Constraints/ZipCodeValidatorTest.php
@@ -88,12 +88,12 @@ class ZipCodeValidatorTest extends \PHPUnit\Framework\TestCase
     /**
      * @doesNotPerformAssertions
      */
-    public function testValidationDoesNothingOnEmptyValueIfIgnoreEmptyIsTrue()
+    public function testValidationIgnoresBlankValues()
     {
         $constraint = new ZipCode('HK');
-        $constraint->ignoreEmpty = true;
 
         $this->validator->validate('', $constraint);
+        $this->validator->validate(null, $constraint);
     }
 
     /** @test */


### PR DESCRIPTION
Stock Symfony validators typically do not validate empty strings and null values. For these cases, special `NotNull` and `NotBlank` validators are provided.
This PR makes the `ZipCode` validator behave the same way and drops the `ignoreEmpty` option for good.
Fixes #39.