### PR TITLE
Add attribute support, fix uppercase issue with getter

### DIFF
--- a/src/ZipCodeValidator/Constraints/ZipCode.php
+++ b/src/ZipCodeValidator/Constraints/ZipCode.php
@@ -2,6 +2,7 @@
 
 namespace ZipCodeValidator\Constraints;
 
+use Attribute;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\MissingOptionsException;
 
@@ -10,6 +11,7 @@ use Symfony\Component\Validator\Exception\MissingOptionsException;
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  * @author Martin Schindler
  */
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD)]
 class ZipCode extends Constraint
 {
     public string $message = 'This value is not a valid ZIP code.';
@@ -18,15 +20,15 @@ class ZipCode extends Constraint
     public bool $strict = true;
     public bool $caseSensitiveCheck = true;
 
-    public function __construct(mixed $options = null)
+    public function __construct(mixed $options = null, array $groups = null, mixed $payload = null)
     {
-        if (null !== $options && !is_array($options)) {
+        if (is_string($options)) {
             $options = array(
                 'iso' => $options
             );
         }
 
-        parent::__construct($options);
+        parent::__construct($options, $groups, $payload);
 
         if (null === $this->iso && null === $this->getter) {
             throw new MissingOptionsException(sprintf('Either the option "iso" or "getter" must be given for constraint %s', __CLASS__), ['iso', 'getter']);

--- a/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
+++ b/src/ZipCodeValidator/Constraints/ZipCodeValidator.php
@@ -235,7 +235,7 @@ class ZipCodeValidator extends ConstraintValidator
                 throw new ConstraintDefinitionException(sprintf($message, $getter, get_class($object)));
             }
 
-            $iso = $object->$getter();
+            $iso = strtoupper($object->$getter() ?? '');
         }
 
         if(empty($iso)){


### PR DESCRIPTION
Fix #48

- I added the Attribute support. I decided to not add `getter` and `iso` parameters in the constructor to avoid introducing BC. If we decide to update the constructor, we'll have to publish a new major version.
- $groups and $payload parameters were overlooked, though and I don't think adding them will break anything. So I added them.
- The `iso` parameter was submitted to `strtoupper`, but not the `getter` parameter, which could cause issues. I fixed that too.